### PR TITLE
BigDecimal.new() -> BigDecimal()

### DIFF
--- a/lib/payday/invoice.rb
+++ b/lib/payday/invoice.rb
@@ -26,12 +26,12 @@ module Payday
 
     # The tax rate that we're applying, as a BigDecimal
     def tax_rate=(value)
-      @tax_rate = BigDecimal.new(value.nil? ? 0 : value.to_s)
+      @tax_rate = BigDecimal(value.nil? ? 0 : value.to_s)
     end
 
     # Shipping rate
     def shipping_rate=(value)
-      @shipping_rate = BigDecimal.new(value.nil? ? 0 : value.to_s)
+      @shipping_rate = BigDecimal(value.nil? ? 0 : value.to_s)
     end
   end
 end

--- a/lib/payday/invoiceable.rb
+++ b/lib/payday/invoiceable.rb
@@ -20,7 +20,7 @@ module Payday::Invoiceable
 
   # Calculates the subtotal of this invoice by adding up all of the line items
   def subtotal
-    line_items.reduce(BigDecimal.new("0")) { |result, item| result += item.amount }
+    line_items.reduce(BigDecimal("0")) { |result, item| result += item.amount }
   end
 
   # The tax for this invoice, as a BigDecimal

--- a/lib/payday/line_item.rb
+++ b/lib/payday/line_item.rb
@@ -20,12 +20,12 @@ module Payday
 
     # Sets the quantity of this {LineItem}
     def quantity=(value)
-      @quantity = BigDecimal.new(value.nil? ? 0 : value.to_s)
+      @quantity = BigDecimal(value.nil? ? 0 : value.to_s)
     end
 
     # Sets the price for this {LineItem}
     def price=(value)
-      @price = BigDecimal.new(value.nil? ? 0 : value.to_s)
+      @price = BigDecimal(value.nil? ? 0 : value.to_s)
     end
   end
 end

--- a/lib/payday/pdf_renderer.rb
+++ b/lib/payday/pdf_renderer.rb
@@ -194,7 +194,7 @@ module Payday
       invoice.line_items.each do |line|
         table_data << [line.description,
                        (line.display_price || number_to_currency(line.price, invoice)),
-                       (line.display_quantity || BigDecimal.new(line.quantity.to_s).to_s("F")),
+                       (line.display_quantity || BigDecimal(line.quantity.to_s).to_s("F")),
                        number_to_currency(line.amount, invoice)]
       end
 

--- a/spec/invoice_spec.rb
+++ b/spec/invoice_spec.rb
@@ -17,9 +17,9 @@ module Payday
       expect(i.ship_to).to eq("There")
       expect(i.notes).to eq("These are some notes.")
       expect(i.line_items[0].description).to eq("Shirts")
-      expect(i.shipping_rate).to eq(BigDecimal.new("15.00"))
+      expect(i.shipping_rate).to eq(BigDecimal("15.00"))
       expect(i.shipping_description).to eq("USPS Priority Mail:")
-      expect(i.tax_rate).to eq(BigDecimal.new("0.125"))
+      expect(i.tax_rate).to eq(BigDecimal("0.125"))
       expect(i.tax_description).to eq("Local Sales Tax, 12.5%")
       expect(i.invoice_date).to eq(Date.civil(1993, 4, 12))
     end
@@ -37,14 +37,14 @@ module Payday
       # $1000 in Hats
       i.line_items << LineItem.new(price: 5, quantity: 200, description: "Hats")
 
-      expect(i.subtotal).to eq(BigDecimal.new("1130"))
+      expect(i.subtotal).to eq(BigDecimal("1130"))
     end
 
     it "should calculate the correct tax rounded to two decimal places" do
       i = Invoice.new(tax_rate: 0.1)
       i.line_items << LineItem.new(price: 20, quantity: 5, description: "Pants")
 
-      expect(i.tax).to eq(BigDecimal.new("10"))
+      expect(i.tax).to eq(BigDecimal("10"))
     end
 
     it "shouldn't apply taxes to invoices with subtotal <= 0" do
@@ -52,7 +52,7 @@ module Payday
       i.line_items << LineItem.new(price: -1, quantity: 100,
         description: "Negative Priced Pants")
 
-      expect(i.tax).to eq(BigDecimal.new("0"))
+      expect(i.tax).to eq(BigDecimal("0"))
     end
 
     it "should calculate the total for an invoice correctly" do
@@ -68,7 +68,7 @@ module Payday
       # $1000 in Hats
       i.line_items << LineItem.new(price: 5, quantity: 200, description: "Hats")
 
-      expect(i.total).to eq(BigDecimal.new("1243"))
+      expect(i.total).to eq(BigDecimal("1243"))
     end
 
     it "is overdue when it's past date and unpaid" do

--- a/spec/line_item_spec.rb
+++ b/spec/line_item_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 module Payday
   describe LineItem do
     it "should be able to be initilized with a price" do
-      li = LineItem.new(price: BigDecimal.new("20"))
-      expect(li.price).to eq(BigDecimal.new("20"))
+      li = LineItem.new(price: BigDecimal("20"))
+      expect(li.price).to eq(BigDecimal("20"))
     end
 
     it "should be able to be initialized with a quantity" do
       li = LineItem.new(quantity: 30)
-      expect(li.quantity).to eq(BigDecimal.new("30"))
+      expect(li.quantity).to eq(BigDecimal("30"))
     end
 
     it "should be able to be initlialized with a description" do
@@ -19,7 +19,7 @@ module Payday
 
     it "should return the correct amount" do
       li = LineItem.new(price: 10, quantity: 12)
-      expect(li.amount).to eq(BigDecimal.new("120"))
+      expect(li.amount).to eq(BigDecimal("120"))
     end
   end
 end


### PR DESCRIPTION
fixes

warning: BigDecimal.new is deprecated; use BigDecimal() method instead.

https://circleci.com/gh/Everapps/evercondo/25029#tests/containers/3